### PR TITLE
Fix a bug of attribute matching

### DIFF
--- a/lib/HTML/FillInForm/Lite.pm
+++ b/lib/HTML/FillInForm/Lite.pm
@@ -90,16 +90,16 @@ sub _unquote{
     $_[0] =~ /(['"]) (.*) \1/xms ? $2 : $_[0]; # ' for poor editors
 }
 sub _get_id{
-    $_[0] =~ /$id    = ($ATTR_VALUE)/xms ? _unquote($1) : undef;
+    $_[0] =~ /$SPACE $id    = ($ATTR_VALUE)/xms ? _unquote($1) : undef;
 }
 sub _get_type{
-    $_[0] =~ /$type  = ($ATTR_VALUE)/xms ? _unquote($1) : undef;
+    $_[0] =~ /$SPACE $type  = ($ATTR_VALUE)/xms ? _unquote($1) : undef;
 }
 sub _get_name{
-    $_[0] =~ /$name  = ($ATTR_VALUE)/xms ? _unquote($1) : undef;
+    $_[0] =~ /$SPACE $name  = ($ATTR_VALUE)/xms ? _unquote($1) : undef;
 }
 sub _get_value{
-    $_[0] =~ /$value = ($ATTR_VALUE)/xms ? _unquote($1) : undef;
+    $_[0] =~ /$SPACE $value = ($ATTR_VALUE)/xms ? _unquote($1) : undef;
 }
 
 #use macro

--- a/t/17suffix.t
+++ b/t/17suffix.t
@@ -1,0 +1,14 @@
+#!perl -w
+
+use strict;
+use Test::More tests => 1;
+
+use HTML::FillInForm::Lite qw(fillinform);
+
+my $html = <<'EOD';
+<input type="text" data-name="baz" name="foo" value="" />
+EOD
+
+like fillinform($html, { foo => "bar" }),
+    qr/value="bar"/xms;
+


### PR DESCRIPTION
`_get_(id|type|name|value)` may return incorrect attribute value as the result.

```perl
my $html = <<'EOD';
<input type="text" data-name="baz" name="foo" value="" />
EOD

fillinform($html, { foo => "bar" });
```

## as-is

`_get_name` returns `'baz'` and the value is not filled.

```html
<input type="text" data-name="baz" name="foo" value="" />
```

## to-be

`_get_name` returns `'foo'` and the value is filled.

```html
<input type="text" data-name="baz" name="foo" value="bar" />
```
